### PR TITLE
Fix a bug when you include a coupon

### DIFF
--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -75,7 +75,7 @@ module Koudoku::Subscription
                 metadata: subscription_owner_metadata
               }
 
-              # Get rid of credit cards for free plans
+              # Only add a card for prices that aren't free
               if plan.price > 0.0 and credit_card_token.present?
                 customer_attributes[:card] = credit_card_token # obtained with Stripe.js
               end

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -66,7 +66,7 @@ module Koudoku::Subscription
             prepare_for_upgrade
 
             begin
-              raise Koudoku::NilCardToken, "No card token received. Check for JavaScript errors breaking Stripe.js on the previous page." unless credit_card_token.present?
+              # raise Koudoku::NilCardToken, "No card token received. Check for JavaScript errors breaking Stripe.js on the previous page." unless credit_card_token.present?
 
               customer_attributes = {
                 description: subscription_owner_description,

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -82,13 +82,6 @@ module Koudoku::Subscription
                 end
               end
 
-              # If the class we're being included in supports coupons ..
-              if respond_to? :coupon
-                if coupon.present? and coupon.free_trial?
-                  customer_attributes[:trial_end] = coupon.free_trial_ends.to_i
-                end
-              end
-
               customer_attributes[:coupon] = @coupon_code if @coupon_code
 
               # create a customer at that package level.

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -71,7 +71,7 @@ module Koudoku::Subscription
               customer_attributes = {
                 description: subscription_owner_description,
                 email: subscription_owner_email,
-                card: credit_card_token, # obtained with Stripe.js
+                plan: plan.stripe_id,
                 metadata: subscription_owner_metadata
               }
 

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -75,6 +75,11 @@ module Koudoku::Subscription
                 metadata: subscription_owner_metadata
               }
 
+              # Get rid of credit cards for free plans
+              if plan.price > 0.0 and credit_card_token.present?
+                customer_attributes[:card] = credit_card_token # obtained with Stripe.js
+              end
+
               # If the class we're being included in supports Rewardful ..
               if respond_to? :rewardful_id
                 if rewardful_id.present?
@@ -117,7 +122,7 @@ module Koudoku::Subscription
 
             # store the customer id.
             self.stripe_id = customer.id
-            self.last_four = customer.sources.retrieve(customer.default_source).last4
+            self.last_four = customer.sources.retrieve(customer.default_source).last4 if customer.cards.count > 0
 
             finalize_new_subscription!
             finalize_upgrade!


### PR DESCRIPTION
This breaks because `trial_end` is not an argument for the customer creation endpoint, where this is hash is used. There is a way to use this argument on the `subscription_attributes`, but it's easier to leave the `trail_from_plan` flag true and set the default trial period via Stripe's dashboard.